### PR TITLE
fix rtbf regex to accomodate page rendered as of april 2017

### DIFF
--- a/plugin.video.belgium/rtbf.py
+++ b/plugin.video.belgium/rtbf.py
@@ -14,9 +14,10 @@ class Channel(channel.Channel):
     def get_categories(self, skip_empty_id = True, return_result=False):
         channel.addDir('Directs', 'DefaultVideo.png', channel_id=self.channel_id, action='get_lives')
         data = channel.get_url(self.main_url + '/auvio/emissions')
-        regex = r"""data-srcset="([^ ]+)[^"]+"\s*/>\s*</div>\s*</figure>\s*<header[^>]+>\s*<a\s+href="([^"]+)[^>]+>\s*<h4[^>]*>([^<]+)"""
+        regex = r"""<header class="rtbf-media-item__header">\s*<a\s+href="([^"]+)[^>]+>\s*<h4[^>]*>([^<]+)"""
         result = []
-        for icon, url, name in re.findall(regex, data):
+        icon = None
+        for url, name in re.findall(regex, data):
             id = url.split('?id=')[1]
             if skip_empty_id and id in id2skip:
                 continue


### PR DESCRIPTION
Hello,

since some days, rtbf plugin is (again) broken.

I modified the regex to get the categories.
I did not know what to do with the Icon (the page itself does not contains any image of the emission. Was it before), so I set it to None.

Hope this helps,


-Sebastien